### PR TITLE
Max extend: fix current extend after sheet size changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.2
+* **Fixed** [#7](https://github.com/flutterwtf/wtf_sliding_sheet/pull/7)
+
 ## 0.6.1
 * **Migrate** to a new repository name
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add it to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  wtf_sliding_sheet: ^0.6.1
+  wtf_sliding_sheet: ^0.6.2
 ```
 
 Install packages from the command line

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -214,7 +214,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.1"
+    version: "0.6.2"
 sdks:
   dart: ">=2.19.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/lib/src/sheet.dart
+++ b/lib/src/sheet.dart
@@ -607,7 +607,7 @@ class _SlidingSheetState extends State<SlidingSheet>
       final RenderBox? footer =
           footerKey.currentContext?.findRenderObject() as RenderBox?;
 
-      final previousMaxExtend =
+      final previousMaxExtent =
           isLaidOut ? (sheetHeight / availableHeight).clamp(0.0, 1.0) : 1.0;
 
       final isChildLaidOut = child?.hasSize == true;
@@ -626,7 +626,7 @@ class _SlidingSheetState extends State<SlidingSheet>
           (childHeight != prevChildHeight ||
               headerHeight != prevHeaderHeight ||
               footerHeight != prevFooterHeight)) {
-        _updateSnappingsAndExtent(previousMaxExtend: previousMaxExtend);
+        _updateSnappingsAndExtent(previousMaxExtent: previousMaxExtent);
         setState(() {});
       }
     });
@@ -703,7 +703,7 @@ class _SlidingSheetState extends State<SlidingSheet>
     }
   }
 
-  void _updateSnappingsAndExtent({num? previousMaxExtend}) {
+  void _updateSnappingsAndExtent({num? previousMaxExtent}) {
     snappings = snapSpec.snappings.map(_normalizeSnap).toList()..sort();
 
     if (extent != null) {
@@ -717,10 +717,10 @@ class _SlidingSheetState extends State<SlidingSheet>
         ..maxExtent = maxExtent
         ..minExtent = minExtent;
 
-      final isCurrentPreviousMaxExtend = previousMaxExtend != null &&
-          (currentExtent - previousMaxExtend).abs() < 0.01;
+      final isCurrentPreviousMaxExtent = previousMaxExtent != null &&
+          (currentExtent - previousMaxExtent).abs() < 0.01;
 
-      if (currentExtent > maxExtent || isCurrentPreviousMaxExtend) {
+      if (currentExtent > maxExtent || isCurrentPreviousMaxExtent) {
         currentExtent = maxExtent;
       }
     }

--- a/lib/src/sheet.dart
+++ b/lib/src/sheet.dart
@@ -11,11 +11,8 @@ import 'specs.dart';
 import 'util.dart';
 
 part 'scrolling.dart';
-
 part 'sheet_controller.dart';
-
 part 'sheet_dialog.dart';
-
 part 'sheet_state.dart';
 
 /// Widget for building sheet
@@ -610,6 +607,9 @@ class _SlidingSheetState extends State<SlidingSheet>
       final RenderBox? footer =
           footerKey.currentContext?.findRenderObject() as RenderBox?;
 
+      final previousMaxExtend =
+          isLaidOut ? (sheetHeight / availableHeight).clamp(0.0, 1.0) : 1.0;
+
       final isChildLaidOut = child?.hasSize == true;
       final prevChildHeight = childHeight;
       childHeight = isChildLaidOut ? child!.size.height : 0;
@@ -626,7 +626,7 @@ class _SlidingSheetState extends State<SlidingSheet>
           (childHeight != prevChildHeight ||
               headerHeight != prevHeaderHeight ||
               footerHeight != prevFooterHeight)) {
-        _updateSnappingsAndExtent();
+        _updateSnappingsAndExtent(previousMaxExtend: previousMaxExtend);
         setState(() {});
       }
     });
@@ -703,7 +703,7 @@ class _SlidingSheetState extends State<SlidingSheet>
     }
   }
 
-  void _updateSnappingsAndExtent() {
+  void _updateSnappingsAndExtent({num? previousMaxExtend}) {
     snappings = snapSpec.snappings.map(_normalizeSnap).toList()..sort();
 
     if (extent != null) {
@@ -717,7 +717,12 @@ class _SlidingSheetState extends State<SlidingSheet>
         ..maxExtent = maxExtent
         ..minExtent = minExtent;
 
-      if (currentExtent > maxExtent) currentExtent = maxExtent;
+      final isCurrentPreviousMaxExtend = previousMaxExtend != null &&
+          (currentExtent - previousMaxExtend).abs() < 0.01;
+
+      if (currentExtent > maxExtent || isCurrentPreviousMaxExtend) {
+        currentExtent = maxExtent;
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wtf_sliding_sheet
 description: A widget that can be dragged and scrolled in a single gesture and snapped to a list of extents.
-version: 0.6.1
+version: 0.6.2
 homepage: https://pub.dev/packages/wtf_sliding_sheet
 repository: https://github.com/flutterwtf/wtf_sliding_sheet
 


### PR DESCRIPTION
When SlidingSheet increases its height and `currentExtent` has value of `maxExtent`, after recalculation of all widget component's height the new value of `maxExtent` will be bigger than previous so the `currentExtent` won't be changed. So that's why SlidingSheet won't be with maximum extention as we expect. Because of than I've created a new varible `previousMaxExtent` in `_measure()` to check in `_updateSnappingsAndExtent()`, whether the previous `currentExtent` had the value of `maxExtent`, and if it's so I change its value to the new value of `maxExtent`. 